### PR TITLE
add fvm (Flutter Version Management) support

### DIFF
--- a/spaceship-flutter.plugin.zsh
+++ b/spaceship-flutter.plugin.zsh
@@ -31,7 +31,13 @@ spaceship_flutter() {
 
   [[ -n "$is_flutter_project" &&  "$is_flutter_project" != "null" ]] || return
 
-  local flutter_version_output=$(flutter --version | awk '/^Flutter/{print $0}')
+  if (( $+commands[fvm] )); then
+    local prefix=(fvm "")
+  else
+    local prefix=""
+  fi
+
+  local flutter_version_output=$(${prefix}flutter --version | awk '/^Flutter/{print $0}')
   local flutter_version=$(printf "$flutter_version_output" | awk '{print $2}')
   local flutter_channel=$(printf "$flutter_version_output" | awk '{print $5}')
   local flutter_channel_section="$(__spaceship_flutter_channel $flutter_channel)"


### PR DESCRIPTION
#### Description

This PR adds support of fvm (Flutter Version Management). It uses `fvm flutter` command if fvm is installed and just `flutter` otherwise.

#### Screenshot

![screenshot](https://github.com/user-attachments/assets/c399a76c-078e-4ef4-98c8-a89337e9ee5f)
